### PR TITLE
READ処理の単体テストの実装

### DIFF
--- a/src/main/java/com/example/country/Country.java
+++ b/src/main/java/com/example/country/Country.java
@@ -1,5 +1,7 @@
 package com.example.country;
 
+import java.util.Objects;
+
 public class Country {
 
     private int countryCode;
@@ -36,5 +38,18 @@ public class Country {
 
     public void setCity(String city) {
         this.city = city;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Country country1 = (Country) o;
+        return Objects.equals(countryCode, country1.countryCode) && Objects.equals(country, country1.country) && Objects.equals(city, country1.city);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(countryCode, country, city);
     }
 }

--- a/src/test/java/com/example/country/CountryServiceTest.java
+++ b/src/test/java/com/example/country/CountryServiceTest.java
@@ -1,0 +1,103 @@
+package com.example.country;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CountryServiceTest {
+
+    @InjectMocks
+    private CountryService countryService;
+
+    @Mock
+    private CountryMapper countryMapper;
+
+    @Test
+    public void 存在する国番号と国名と都市名を全て返す() {
+        List<Country> countryList = List.of(
+                new Country(31, "Netherlands", "Amsterdam"),
+                new Country(33, "France", "Paris"),
+                new Country(34, "Spain", "Madrid"),
+                new Country(44, "the United Kingdom of Great Britain and Northern Ireland", "London"),
+                new Country(49, "Germany", "Berlin"));
+        doReturn(countryList).when(countryMapper).findAll();
+
+        List<Country> actual = countryService.findAll();
+        assertThat(actual).isEqualTo(countryList);
+
+        verify(countryMapper, times(1)).findAll();
+    }
+
+    @Test
+    public void 指定した国番号が存在する場合はその国番号と国名と都市名を返す() {
+        doReturn(Optional.of(new Country(44, "the United Kingdom of Great Britain and Northern Ireland", "London"))).when(countryMapper).findByCountryCode(44);
+
+        Country actual = countryService.findByCountryCode(44);
+        assertThat(actual).isEqualTo(new Country(44, "the United Kingdom of Great Britain and Northern Ireland", "London"));
+
+        verify(countryMapper, times(1)).findByCountryCode(44);
+    }
+
+    @Test
+    public void 指定した国番号が存在しない場合は例外をスローする() {
+        doReturn(Optional.empty()).when(countryMapper).findByCountryCode(50);
+
+        assertThatThrownBy(() -> countryService.findByCountryCode(50)).isInstanceOf(CountryNotFoundException.class);
+
+        verify(countryMapper, times(1)).findByCountryCode(50);
+    }
+
+    @Test
+    public void 指定した国名の頭文字で存在する国番号と国名と都市名を返す() {
+        doReturn(List.of(new Country(49, "Germany", "Berlin"))).when(countryMapper).findByCountryStartingWith("g");
+
+        List<Country> actual = countryService.findByCountry("g");
+        assertThat(actual).isEqualTo(List.of(new Country(49, "Germany", "Berlin")));
+
+        verify(countryMapper, times(1)).findByCountryStartingWith("g");
+    }
+
+    @Test
+    public void 指定した国名の頭文字で存在しない国名を検索し何も返さない() {
+        doReturn(Collections.emptyList()).when(countryMapper).findByCountryStartingWith("k");
+
+        List<Country> actual = countryService.findByCountry("k");
+        assertThat(actual).isEmpty();
+
+        verify(countryMapper, times(1)).findByCountryStartingWith("k");
+    }
+
+    @Test
+    public void 指定した都市名の頭文字で存在する国番号と国名と都市名を返す() {
+        doReturn(List.of(new Country(34, "Spain", "Madrid"))).when(countryMapper).findByCityStartingWith("m");
+
+        List<Country> actual = countryService.findByCity("m");
+        assertThat(actual).isEqualTo(List.of(new Country(34, "Spain", "Madrid")));
+
+        verify(countryMapper, times(1)).findByCityStartingWith("m");
+    }
+
+    @Test
+    public void 指定した都市名の頭文字で存在しない都市名を検索し何も返さない() {
+        doReturn(Collections.emptyList()).when(countryMapper).findByCityStartingWith("y");
+
+        List<Country> actual = countryService.findByCity("y");
+        assertThat(actual).isEmpty();
+
+        verify(countryMapper, times(1)).findByCityStartingWith("y");
+    }
+
+}


### PR DESCRIPTION
# 概要

Spring + MySQL + MyBatis を使用し、CRUD処理を実装します。今回はRead処理の単体テストを実装しました。

# 動作確認
- 存在する国番号と国名と都市名を全て返す
<img width="1345" alt="1Screenshot 2024-08-06 at 10 49 50" src="https://github.com/user-attachments/assets/ca52b5dc-3294-4539-8f67-42ca1c3ec4eb">




- 指定した国番号が存在する場合はその国番号と国名と都市名を返す

<img width="1319" alt="2Screenshot 2024-08-06 at 10 50 46" src="https://github.com/user-attachments/assets/c124b05c-12f0-434e-8234-6b5e49f58317">



- 指定した国番号が存在しない場合は例外をスローする

<img width="1322" alt="3Screenshot 2024-08-06 at 10 51 13" src="https://github.com/user-attachments/assets/0d9790a5-0092-429b-8631-5c417968dfce">



- 指定した国名の頭文字で存在する国番号と国名と都市名を返す

<img width="1321" alt="4Screenshot 2024-08-06 at 10 51 47" src="https://github.com/user-attachments/assets/1c97ba49-9e98-4bd5-8fa5-d59f44563620">



- 指定した国名の頭文字で存在しない国名を検索し何も返さない
<img width="1321" alt="5Screenshot 2024-08-06 at 10 59 05" src="https://github.com/user-attachments/assets/611e712a-88bc-4d9e-8aa2-43ddae008eb9">




- 指定した都市名の頭文字で存在する国番号と国名と都市名を返す
<img width="1319" alt="6Screenshot 2024-08-06 at 10 52 35" src="https://github.com/user-attachments/assets/177088cd-8420-467f-a22e-6823737240c0">



- 指定した都市名の頭文字で存在しない都市名を検索し何も返さない
<img width="1325" alt="7Screenshot 2024-08-06 at 11 00 15" src="https://github.com/user-attachments/assets/9fc3dc98-7c98-455a-b012-809616c20d01">





