### PR TITLE
CREATE UPDATE DELETE処理の単体テストの実装

### DIFF
--- a/src/test/java/com/example/country/CountryServiceTest.java
+++ b/src/test/java/com/example/country/CountryServiceTest.java
@@ -100,4 +100,63 @@ class CountryServiceTest {
         verify(countryMapper, times(1)).findByCityStartingWith("y");
     }
 
+    @Test
+    public void 新たな国番号と国名と都市名を登録する() {
+        doReturn(Optional.empty()).when(countryMapper).findByCountryCode(32);
+
+        Country actual = countryService.insert(32, "Belgium", "Brussels");
+        assertThat(actual).isEqualTo(new Country(32, "Belgium", "Brussels"));
+
+        verify(countryMapper, times(1)).insert(new Country (32, "Belgium", "Brussels"));
+    }
+
+    @Test
+    public void 登録しようとした国番号が既に存在する場合は例外をスローする() {
+        doReturn(Optional.of(new Country(33, "France", "Paris"))).when(countryMapper).findByCountryCode(33);
+
+        assertThatThrownBy(() -> countryService.insert(33, "France", "Paris")).isInstanceOf(CountryDuplicatedException.class);
+
+        verify(countryMapper, times(1)).findByCountryCode(33);
+    }
+
+    @Test
+    public void 国名と都市名を更新しようと指定した国番号が存在する場合は国名と都市名を更新する() {
+        Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
+        doReturn(Optional.of(existingCountry)).when(countryMapper).findByCountryCode(31);
+
+        Country updatedCountry = new Country(31, "Holland", "Rotterdam");
+        Country actual = countryService.update(31, "Holland", "Rotterdam");
+        assertThat(actual).isEqualTo(updatedCountry);
+
+        verify(countryMapper, times(1)).update(updatedCountry);
+    }
+
+    @Test
+    public void 国名と都市名を更新しようと指定した国番号が存在しない場合は例外をスローする() {
+        doReturn(Optional.empty()).when(countryMapper).findByCountryCode(351);
+
+        assertThatThrownBy(() -> countryService.update(351, "Portugal", "Lisbon")).isInstanceOf(CountryNotFoundException.class);
+
+        verify(countryMapper, times(1)).findByCountryCode(351);
+    }
+
+    @Test
+    public void 削除しようと指定した国番号が存在する場合は削除する() {
+        Country existingCountry = new Country(49, "Germany", "Berlin");
+        doReturn(Optional.of(existingCountry)).when(countryMapper).findByCountryCode(49);
+
+        Country actual = countryService.delete(49);
+        assertThat(actual).isEqualTo(existingCountry);
+
+        verify(countryMapper, times(1)).delete(existingCountry);
+    }
+
+    @Test
+    public void 削除しようと指定した国番号が存在しない場合は例外をスローする() {
+        doReturn(Optional.empty()).when(countryMapper).findByCountryCode(352);
+
+        assertThatThrownBy(() -> countryService.delete(352)).isInstanceOf(CountryNotFoundException.class);
+
+        verify(countryMapper, times(1)).findByCountryCode(352);
+    }
 }


### PR DESCRIPTION
# 概要
Spring + MySQL + MyBatis を使用し、CRUD処理を実装します。今回はCreate Update Delete処理の単体テストを実装しました。

# 動作確認
- 新たな国番号と国名と都市名を登録する

<img width="1357" alt="1Screenshot 2024-08-06 at 16 00 37" src="https://github.com/user-attachments/assets/3f4c5a12-c33a-4eb3-8db1-ec3e2455dbf9">


- 登録しようとした国番号が既に存在する場合は例外をスローする

<img width="1325" alt="2Screenshot 2024-08-06 at 16 01 03" src="https://github.com/user-attachments/assets/d555461f-65b3-4f2e-8939-0a251e725c22">


- 国名と都市名を更新しようと指定した国番号が存在する場合は国名と都市名を更新する

<img width="1319" alt="3Screenshot 2024-08-06 at 16 01 26" src="https://github.com/user-attachments/assets/3ca70f6b-c3a4-42e9-8742-18ededbf624b">


- 国名と都市名を更新しようと指定した国番号が存在しない場合は例外をスローする

<img width="1345" alt="4Screenshot 2024-08-06 at 16 01 51" src="https://github.com/user-attachments/assets/408f4d0b-fb6a-4516-8d76-b6cf4bb5b06f">


- 削除しようと指定した国番号が存在する場合は削除する

<img width="1354" alt="5Screenshot 2024-08-06 at 16 02 12" src="https://github.com/user-attachments/assets/3827378a-15e1-4f09-9e7d-567f19ae6703">


- 削除しようと指定した国番号が存在しない場合は例外をスローする

<img width="1350" alt="6Screenshot 2024-08-06 at 16 02 33" src="https://github.com/user-attachments/assets/9494aad7-a646-4ce4-b289-a77c53954913">

