### PR TITLE
Controllerクラスの単体テストの実装、READ処理の単体テストの追加

### DIFF
--- a/src/test/java/com/example/country/CountryControllerTest.java
+++ b/src/test/java/com/example/country/CountryControllerTest.java
@@ -30,7 +30,7 @@ class CountryControllerTest {
     private CountryService countryService;
 
     @Test
-    public void 全ての国を取得する() throws Exception {
+    public void 全ての国を取得すること() throws Exception {
         List<Country> countryList = List.of(
                 new Country(31, "Netherlands", "Amsterdam"),
                 new Country(33, "France", "Paris"));
@@ -44,7 +44,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 指定した国名と都市名の頭文字を含む国を取得する() throws Exception {
+    public void 指定した国名と都市名の頭文字を含む国を取得すること() throws Exception {
         when(countryService.getCountries("n", "a")).thenReturn(List.of(new Country(31, "Netherlands", "Amsterdam")));
 
         mockMvc.perform(get("/countries")
@@ -57,7 +57,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 指定した存在しない国名や都市名の頭文字で何も返さない() throws Exception {
+    public void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
         when(countryService.getCountries("", "")).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/countries")
@@ -70,7 +70,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 指定した国番号を取得する() throws Exception {
+    public void 指定した国番号を取得すること() throws Exception {
         when(countryService.findByCountryCode(31)).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
 
         mockMvc.perform(get("/countries/{country_code}", 31))
@@ -81,7 +81,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 指定した国番号が存在しない場合は例外メッセージをスローする() throws Exception {
+    public void 指定した国番号が存在しない場合は例外メッセージをスローすること() throws Exception {
         when(countryService.findByCountryCode(999)).thenThrow(new CountryNotFoundException("Country with code 999 not found"));
 
         mockMvc.perform(get("/countries/{country_code}", 999))
@@ -92,7 +92,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 新たな国番号と国名と都市名を登録する() throws Exception {
+    public void 新たな国番号と国名と都市名を登録すること() throws Exception {
         when(countryService.insert(31, "Netherlands", "Amsterdam")).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
 
         mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
@@ -111,7 +111,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 登録しようとした国番号が既に存在する場合は例外メッセージをスローする() throws Exception {
+    public void 登録しようとした国番号が既に存在する場合は例外メッセージをスローすること() throws Exception {
         when(countryService.findByCountryCode(31)).thenThrow(new CountryDuplicatedException("Country with code 31 duplicated"));
 
         mockMvc.perform(get("/countries/{country_code}", 31))
@@ -122,7 +122,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 国番号を指定して国名と都市名を更新する() throws Exception {
+    public void 国番号を指定して国名と都市名を更新すること() throws Exception {
         Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
         when(countryService.update(31, "Netherlands", "Amsterdam")).thenReturn(existingCountry);
 
@@ -142,7 +142,7 @@ class CountryControllerTest {
     }
 
     @Test
-    public void 国番号を指定して国を削除する() throws Exception {
+    public void 国番号を指定して国を削除すること() throws Exception {
         Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
         when(countryService.delete(31)).thenReturn(existingCountry);
 

--- a/src/test/java/com/example/country/CountryControllerTest.java
+++ b/src/test/java/com/example/country/CountryControllerTest.java
@@ -1,0 +1,155 @@
+package com.example.country;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CountryController.class)
+class CountryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CountryService countryService;
+
+    @Test
+    public void 全ての国を取得する() throws Exception {
+        List<Country> countryList = List.of(
+                new Country(31, "Netherlands", "Amsterdam"),
+                new Country(33, "France", "Paris"));
+        when(countryService.getCountries("", "")).thenReturn(countryList);
+
+        mockMvc.perform(get("/countries"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[{\"countryCode\":31,\"country\":\"Netherlands\",\"city\":\"Amsterdam\"},{\"countryCode\":33,\"country\":\"France\",\"city\":\"Paris\"}]"));
+
+        verify(countryService, times(1)).getCountries("","");
+    }
+
+    @Test
+    public void 指定した国名と都市名の頭文字を含む国を取得する() throws Exception {
+        when(countryService.getCountries("n", "a")).thenReturn(List.of(new Country(31, "Netherlands", "Amsterdam")));
+
+        mockMvc.perform(get("/countries")
+                        .param("countryStartsWith", "n")
+                        .param("cityStartsWith", "a"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[{\"countryCode\":31,\"country\":\"Netherlands\",\"city\":\"Amsterdam\"}]"));
+
+        verify(countryService, times(1)).getCountries("n","a");
+    }
+
+    @Test
+    public void 指定した存在しない国名や都市名の頭文字で何も返さない() throws Exception {
+        when(countryService.getCountries("", "")).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/countries")
+                        .param("countryStartsWith", "")
+                        .param("cityStartsWith", ""))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+
+        verify(countryService, times(1)).getCountries("","");
+    }
+
+    @Test
+    public void 指定した国番号を取得する() throws Exception {
+        when(countryService.findByCountryCode(31)).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
+
+        mockMvc.perform(get("/countries/{country_code}", 31))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"countryCode\":31,\"country\":\"Netherlands\",\"city\":\"Amsterdam\"}"));
+
+        verify(countryService, times(1)).findByCountryCode(31);
+    }
+
+    @Test
+    public void 指定した国番号が存在しない場合は例外メッセージをスローする() throws Exception {
+        when(countryService.findByCountryCode(999)).thenThrow(new CountryNotFoundException("Country with code 999 not found"));
+
+        mockMvc.perform(get("/countries/{country_code}", 999))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json("{\"message\": \"Country with code 999 not found\"}"));
+
+        verify(countryService, times(1)).findByCountryCode(999);
+    }
+
+    @Test
+    public void 新たな国番号と国名と都市名を登録する() throws Exception {
+        when(countryService.insert(31, "Netherlands", "Amsterdam")).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
+
+        mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                   "countryCode": 31,
+                   "country": "Netherlands",
+                   "city": "Amsterdam"
+                }
+                """
+                ))
+                .andExpect(status().isCreated())
+                .andExpect(content().json("{\"message\": \"country created\"}"));
+
+        verify(countryService, times(1)).insert(31, "Netherlands", "Amsterdam");
+    }
+
+    @Test
+    public void 登録しようとした国番号が既に存在する場合は例外メッセージをスローする() throws Exception {
+        when(countryService.findByCountryCode(31)).thenThrow(new CountryDuplicatedException("Country with code 31 duplicated"));
+
+        mockMvc.perform(get("/countries/{country_code}", 31))
+                .andExpect(status().isConflict())
+                .andExpect(content().json("{\"message\": \"Country with code 31 duplicated\"}"));
+
+        verify(countryService, times(1)).findByCountryCode(31);
+    }
+
+    @Test
+    public void 国番号を指定して国名と都市名を更新する() throws Exception {
+        Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
+        when(countryService.update(31, "Netherlands", "Amsterdam")).thenReturn(existingCountry);
+
+        mockMvc.perform(patch("/countries/{country_code}", 31).contentType(MediaType.APPLICATION_JSON).content(
+                        """
+                        {
+                           "countryCode": 31,
+                           "country": "Holland",
+                           "city": "Rotterdam"
+                        }
+                        """
+                ))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"message\": \"country updated\"}"));
+
+        verify(countryService, times(1)).update(31, "Holland", "Rotterdam");
+    }
+
+    @Test
+    public void 国番号を指定して国を削除する() throws Exception {
+        Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
+        when(countryService.delete(31)).thenReturn(existingCountry);
+
+        mockMvc.perform(delete("/countries/{country_code}", 31))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"message\": \"country deleted\"}"));
+
+        verify(countryService, times(1)).delete(31);
+    }
+}

--- a/src/test/java/com/example/country/CountryServiceTest.java
+++ b/src/test/java/com/example/country/CountryServiceTest.java
@@ -101,6 +101,42 @@ class CountryServiceTest {
     }
 
     @Test
+    public void 国名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返す() {
+        doReturn(List.of(new Country(49, "Germany", "Berlin"))).when(countryMapper).findByCountryStartingWith("g");
+
+        List<Country> actual = countryService.getCountries("g","");
+        assertThat(actual).isEqualTo(List.of(new Country(49, "Germany", "Berlin")));
+
+        verify(countryMapper, times(1)).findByCountryStartingWith("g");
+    }
+
+    @Test
+    public void 都市名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返す() {
+        doReturn(List.of(new Country(34, "Spain", "Madrid"))).when(countryMapper).findByCityStartingWith("m");
+
+        List<Country> actual = countryService.getCountries("","m");
+        assertThat(actual).isEqualTo(List.of(new Country(34, "Spain", "Madrid")));
+
+        verify(countryMapper, times(1)).findByCityStartingWith("m");
+    }
+
+    @Test
+    public void 国名と都市名を空白で検索し存在する国番号と国名と都市名を全て返す() {
+        List<Country> countryList = List.of(
+                new Country(31, "Netherlands", "Amsterdam"),
+                new Country(33, "France", "Paris"),
+                new Country(34, "Spain", "Madrid"),
+                new Country(44, "the United Kingdom of Great Britain and Northern Ireland", "London"),
+                new Country(49, "Germany", "Berlin"));
+        doReturn(countryList).when(countryMapper).findAll();
+
+        List<Country> actual = countryService.getCountries("","");
+        assertThat(actual).isEqualTo(countryList);
+
+        verify(countryMapper, times(1)).findAll();
+    }
+
+    @Test
     public void 新たな国番号と国名と都市名を登録する() {
         doReturn(Optional.empty()).when(countryMapper).findByCountryCode(32);
 

--- a/src/test/java/com/example/country/CountryServiceTest.java
+++ b/src/test/java/com/example/country/CountryServiceTest.java
@@ -26,7 +26,7 @@ class CountryServiceTest {
     private CountryMapper countryMapper;
 
     @Test
-    public void 存在する国番号と国名と都市名を全て返す() {
+    public void 存在する国番号と国名と都市名を全て返すこと() {
         List<Country> countryList = List.of(
                 new Country(31, "Netherlands", "Amsterdam"),
                 new Country(33, "France", "Paris"),
@@ -42,7 +42,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 指定した国番号が存在する場合はその国番号と国名と都市名を返す() {
+    public void 指定した国番号が存在する場合はその国番号と国名と都市名を返すこと() {
         doReturn(Optional.of(new Country(44, "the United Kingdom of Great Britain and Northern Ireland", "London"))).when(countryMapper).findByCountryCode(44);
 
         Country actual = countryService.findByCountryCode(44);
@@ -52,7 +52,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 指定した国番号が存在しない場合は例外をスローする() {
+    public void 指定した国番号が存在しない場合は例外をスローすること() {
         doReturn(Optional.empty()).when(countryMapper).findByCountryCode(50);
 
         assertThatThrownBy(() -> countryService.findByCountryCode(50)).isInstanceOf(CountryNotFoundException.class);
@@ -61,7 +61,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 指定した国名の頭文字で存在する国番号と国名と都市名を返す() {
+    public void 指定した国名の頭文字で存在する国番号と国名と都市名を返すこと() {
         doReturn(List.of(new Country(49, "Germany", "Berlin"))).when(countryMapper).findByCountryStartingWith("g");
 
         List<Country> actual = countryService.findByCountry("g");
@@ -71,7 +71,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 指定した国名の頭文字で存在しない国名を検索し何も返さない() {
+    public void 指定した国名の頭文字で存在しない国名を検索し何も返さないこと() {
         doReturn(Collections.emptyList()).when(countryMapper).findByCountryStartingWith("k");
 
         List<Country> actual = countryService.findByCountry("k");
@@ -81,7 +81,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 指定した都市名の頭文字で存在する国番号と国名と都市名を返す() {
+    public void 指定した都市名の頭文字で存在する国番号と国名と都市名を返すこと() {
         doReturn(List.of(new Country(34, "Spain", "Madrid"))).when(countryMapper).findByCityStartingWith("m");
 
         List<Country> actual = countryService.findByCity("m");
@@ -91,7 +91,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 指定した都市名の頭文字で存在しない都市名を検索し何も返さない() {
+    public void 指定した都市名の頭文字で存在しない都市名を検索し何も返さないこと() {
         doReturn(Collections.emptyList()).when(countryMapper).findByCityStartingWith("y");
 
         List<Country> actual = countryService.findByCity("y");
@@ -101,7 +101,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 国名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返す() {
+    public void 国名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返すこと() {
         doReturn(List.of(new Country(49, "Germany", "Berlin"))).when(countryMapper).findByCountryStartingWith("g");
 
         List<Country> actual = countryService.getCountries("g","");
@@ -111,7 +111,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 都市名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返す() {
+    public void 都市名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返すこと() {
         doReturn(List.of(new Country(34, "Spain", "Madrid"))).when(countryMapper).findByCityStartingWith("m");
 
         List<Country> actual = countryService.getCountries("","m");
@@ -121,7 +121,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 国名と都市名を空白で検索し存在する国番号と国名と都市名を全て返す() {
+    public void 国名と都市名を空白で検索し存在する国番号と国名と都市名を全て返すこと() {
         List<Country> countryList = List.of(
                 new Country(31, "Netherlands", "Amsterdam"),
                 new Country(33, "France", "Paris"),
@@ -137,7 +137,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 新たな国番号と国名と都市名を登録する() {
+    public void 新たな国番号と国名と都市名を登録すること() {
         doReturn(Optional.empty()).when(countryMapper).findByCountryCode(32);
 
         Country actual = countryService.insert(32, "Belgium", "Brussels");
@@ -147,7 +147,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 登録しようとした国番号が既に存在する場合は例外をスローする() {
+    public void 登録しようとした国番号が既に存在する場合は例外をスローすること() {
         doReturn(Optional.of(new Country(33, "France", "Paris"))).when(countryMapper).findByCountryCode(33);
 
         assertThatThrownBy(() -> countryService.insert(33, "France", "Paris")).isInstanceOf(CountryDuplicatedException.class);
@@ -156,7 +156,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 国名と都市名を更新しようと指定した国番号が存在する場合は国名と都市名を更新する() {
+    public void 国名と都市名を更新しようと指定した国番号が存在する場合は国名と都市名を更新すること() {
         Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
         doReturn(Optional.of(existingCountry)).when(countryMapper).findByCountryCode(31);
 
@@ -168,7 +168,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 国名と都市名を更新しようと指定した国番号が存在しない場合は例外をスローする() {
+    public void 国名と都市名を更新しようと指定した国番号が存在しない場合は例外をスローすること() {
         doReturn(Optional.empty()).when(countryMapper).findByCountryCode(351);
 
         assertThatThrownBy(() -> countryService.update(351, "Portugal", "Lisbon")).isInstanceOf(CountryNotFoundException.class);
@@ -177,7 +177,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 削除しようと指定した国番号が存在する場合は削除する() {
+    public void 削除しようと指定した国番号が存在する場合は削除すること() {
         Country existingCountry = new Country(49, "Germany", "Berlin");
         doReturn(Optional.of(existingCountry)).when(countryMapper).findByCountryCode(49);
 
@@ -188,7 +188,7 @@ class CountryServiceTest {
     }
 
     @Test
-    public void 削除しようと指定した国番号が存在しない場合は例外をスローする() {
+    public void 削除しようと指定した国番号が存在しない場合は例外をスローすること() {
         doReturn(Optional.empty()).when(countryMapper).findByCountryCode(352);
 
         assertThatThrownBy(() -> countryService.delete(352)).isInstanceOf(CountryNotFoundException.class);


### PR DESCRIPTION
# 概要
Spring + MySQL + MyBatis を使用し、CRUD処理を実装します。今回はControllerクラスの単体テストを実装しました。
（+で前々回のREAD処理の単体テストで不足していた分を追加してます。）

# 動作確認

- 下記9項目の動作を確認しました。
<img width="1387" alt="Screenshot 2024-08-08 at 19 22 27" src="https://github.com/user-attachments/assets/6d4934b0-770c-4875-98e9-89c4275aa789">

- 下記3項目は前々回のREAD処理の単体テストで不足していた分です。
-  国名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返す
<img width="1340" alt="8(10-7で提出)Screenshot 2024-08-07 at 23 34 19" src="https://github.com/user-attachments/assets/6369fbf1-8733-4272-96bd-401ce585a5b1">

-  都市名の頭文字のみ指定した場合それに該当する国番号と国名と都市名を返す
<img width="1326" alt="9(10-7で提出)Screenshot 2024-08-08 at 15 18 19" src="https://github.com/user-attachments/assets/458339be-59a2-47bc-87f4-df1cba495d5f">

- 国名と都市名を空白で検索し存在する国番号と国名と都市名を全て返す
<img width="1336" alt="10(10-7で提出)Screenshot 2024-08-08 at 18 33 06" src="https://github.com/user-attachments/assets/6f683730-0a11-4639-95ad-d65a45646081">
