### PR TITLE
DBテストの実装、Controllerクラスの単体テストの修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
+	testImplementation 'com.github.database-rider:rider-spring:1.44.0'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/test/java/com/example/country/CountryControllerTest.java
+++ b/src/test/java/com/example/country/CountryControllerTest.java
@@ -58,15 +58,15 @@ class CountryControllerTest {
 
     @Test
     public void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
-        when(countryService.getCountries("", "")).thenReturn(Collections.emptyList());
+        when(countryService.getCountries("k", "y")).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/countries")
-                        .param("countryStartsWith", "")
-                        .param("cityStartsWith", ""))
+                        .param("countryStartsWith", "k")
+                        .param("cityStartsWith", "y"))
                 .andExpect(status().isOk())
                 .andExpect(content().json("[]"));
 
-        verify(countryService, times(1)).getCountries("","");
+        verify(countryService, times(1)).getCountries("k","y");
     }
 
     @Test

--- a/src/test/java/com/example/country/CountryMapperTest.java
+++ b/src/test/java/com/example/country/CountryMapperTest.java
@@ -1,0 +1,135 @@
+package com.example.country;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CountryMapperTest {
+
+    @Autowired
+    CountryMapper countryMapper;
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 全ての国が取得できること() {
+        List<Country> countries = countryMapper.findAll();
+        assertThat(countries)
+                .hasSize(3)
+                .contains(
+                        new Country(36, "Hungary", "Budapest"),
+                        new Country(43, "Austria", "Vienna"),
+                        new Country(420, "The Czech Republic", "Prague")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した国名の頭文字を含む国が取得できること() {
+        List<Country> countries = countryMapper.findByCountryStartingWith("a");
+        assertThat(countries)
+                .hasSize(1)
+                .contains(
+                        new Country(43, "Austria", "Vienna")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した国名の頭文字が存在しない場合取得されるリストが空であること() {
+        List<Country> countries = countryMapper.findByCountryStartingWith("j");
+        assertThat(countries)
+                .isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した都市名の頭文字を含む国が取得できること() {
+        List<Country> countries = countryMapper.findByCityStartingWith("b");
+        assertThat(countries)
+                .hasSize(1)
+                .contains(
+                        new Country(36, "Hungary", "Budapest")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した都市名の頭文字が存在しない場合取得されるリストが空であること() {
+        List<Country> countries = countryMapper.findByCityStartingWith("a");
+        assertThat(countries)
+                .isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した国番号が取得できること() {
+        Optional<Country> countries = countryMapper.findByCountryCode(420);
+        assertThat(countries)
+                .isPresent()
+                .hasValue(
+                        new Country(420, "The Czech Republic", "Prague")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @ExpectedDataSet(value = "datasets/insert-countries.yml")
+    @Transactional
+    void 新たな国を登録できること() {
+        Country country = new Country(385, "Croatia", "Zagreb");
+        countryMapper.insert(country);
+
+        Optional<Country> insertCountries = countryMapper.findByCountryCode(country.getCountryCode());
+        assertThat(insertCountries)
+                .isPresent();
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @ExpectedDataSet(value = "datasets/update-countries.yml")
+    @Transactional
+    void 国番号を指定して国名と都市名を更新できること() {
+        Country existingCountry = new Country(36, "Republic of Hungary", "Szentendre");
+        countryMapper.update(existingCountry);
+
+        Optional<Country> updateCountries = countryMapper.findByCountryCode(36);
+        assertThat(updateCountries)
+                .isPresent()
+                .hasValue(
+                        new Country(36, "Republic of Hungary", "Szentendre")
+                );
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @ExpectedDataSet(value = "datasets/delete-countries.yml")
+    @Transactional
+    void 国番号を指定して国を削除できること() {
+        Country existingCountry = new Country(420, "The Czech Republic", "Prague");
+        countryMapper.delete(existingCountry);
+
+        Optional<Country> deleteCountries = countryMapper.findByCountryCode(420);
+        assertThat(deleteCountries)
+                .isEmpty();
+    }
+
+}

--- a/src/test/resources/datasets/countries.yml
+++ b/src/test/resources/datasets/countries.yml
@@ -1,0 +1,10 @@
+countries:
+  - country_code: 36
+    country: "Hungary"
+    city: "Budapest"
+  - country_code: 43
+    country: "Austria"
+    city: "Vienna"
+  - country_code: 420
+    country: "The Czech Republic"
+    city: "Prague"

--- a/src/test/resources/datasets/delete-countries.yml
+++ b/src/test/resources/datasets/delete-countries.yml
@@ -1,0 +1,7 @@
+countries:
+  - country_code: 36
+    country: "Hungary"
+    city: "Budapest"
+  - country_code: 43
+    country: "Austria"
+    city: "Vienna"

--- a/src/test/resources/datasets/insert-countries.yml
+++ b/src/test/resources/datasets/insert-countries.yml
@@ -1,0 +1,13 @@
+countries:
+  - country_code: 36
+    country: "Hungary"
+    city: "Budapest"
+  - country_code: 43
+    country: "Austria"
+    city: "Vienna"
+  - country_code: 385
+    country: "Croatia"
+    city: "Zagreb"
+  - country_code: 420
+    country: "The Czech Republic"
+    city: "Prague"

--- a/src/test/resources/datasets/update-countries.yml
+++ b/src/test/resources/datasets/update-countries.yml
@@ -1,0 +1,10 @@
+countries:
+  - country_code: 36
+    country: "Republic of Hungary"
+    city: "Szentendre"
+  - country_code: 43
+    country: "Austria"
+    city: "Vienna"
+  - country_code: 420
+    country: "The Czech Republic"
+    city: "Prague"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: country_database
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: jdbc:mysql://localhost:3307/country_database
+  user: user
+  password: password


### PR DESCRIPTION
# 概要
Spring + MySQL + MyBatis を使用し、CRUD処理を実装します。今回はDBテストを実装しました。
（+で前回のControllerクラスの単体テストで誤っていた箇所を修正してます。）

# 動作確認
- 下記9項目の動作を確認しました。
<img width="1327" alt="Screenshot 2024-08-29 at 12 08 52" src="https://github.com/user-attachments/assets/c2951536-6f14-4fac-bb7e-78c13f5dc9e3">

- テスト名と実際の内容とに相違があったため、下記通り"k"と"y"を加筆しました。
<img width="1342" alt="Screenshot 2024-08-29 at 12 20 11" src="https://github.com/user-attachments/assets/d52f2d93-c86e-4cc7-abdc-18aabb8e1c90">
