### PR TITLE
結合テストの実装、Controllerクラスの単体テストの修正

### DIFF
--- a/src/test/java/com/example/country/CountryControllerTest.java
+++ b/src/test/java/com/example/country/CountryControllerTest.java
@@ -24,13 +24,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class CountryControllerTest {
 
     @Autowired
-    private MockMvc mockMvc;
+    MockMvc mockMvc;
 
     @MockBean
-    private CountryService countryService;
+    CountryService countryService;
 
     @Test
-    public void 全ての国を取得すること() throws Exception {
+    void 全ての国を取得すること() throws Exception {
         List<Country> countryList = List.of(
                 new Country(31, "Netherlands", "Amsterdam"),
                 new Country(33, "France", "Paris"));
@@ -38,91 +38,155 @@ class CountryControllerTest {
 
         mockMvc.perform(get("/countries"))
                 .andExpect(status().isOk())
-                .andExpect(content().json("[{\"countryCode\":31,\"country\":\"Netherlands\",\"city\":\"Amsterdam\"},{\"countryCode\":33,\"country\":\"France\",\"city\":\"Paris\"}]"));
+                .andExpect(content().json(
+                        """
+                            [
+                                {
+                                    "countryCode":31,
+                                    "country":"Netherlands",
+                                    "city":"Amsterdam"
+                                },
+                                {
+                                    "countryCode":33,
+                                    "country":"France",
+                                    "city":"Paris"
+                                }
+                            ]
+                        """
+                ));
 
         verify(countryService, times(1)).getCountries("","");
     }
 
     @Test
-    public void 指定した国名と都市名の頭文字を含む国を取得すること() throws Exception {
+    void 指定した国名と都市名の頭文字を含む国を取得すること() throws Exception {
         when(countryService.getCountries("n", "a")).thenReturn(List.of(new Country(31, "Netherlands", "Amsterdam")));
 
         mockMvc.perform(get("/countries")
                         .param("countryStartsWith", "n")
                         .param("cityStartsWith", "a"))
                 .andExpect(status().isOk())
-                .andExpect(content().json("[{\"countryCode\":31,\"country\":\"Netherlands\",\"city\":\"Amsterdam\"}]"));
+                .andExpect(content().json(
+                        """
+                            [
+                                {
+                                    "countryCode":31,
+                                    "country":"Netherlands",
+                                    "city":"Amsterdam"
+                                }
+                            ]
+                        """
+                ));
 
         verify(countryService, times(1)).getCountries("n","a");
     }
 
     @Test
-    public void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
+    void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
         when(countryService.getCountries("k", "y")).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/countries")
                         .param("countryStartsWith", "k")
                         .param("cityStartsWith", "y"))
                 .andExpect(status().isOk())
-                .andExpect(content().json("[]"));
+                .andExpect(content().json(
+                        """
+                            []
+                        """
+                ));
 
         verify(countryService, times(1)).getCountries("k","y");
     }
 
     @Test
-    public void 指定した国番号を取得すること() throws Exception {
+    void 指定した国番号を取得すること() throws Exception {
         when(countryService.findByCountryCode(31)).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
 
         mockMvc.perform(get("/countries/{country_code}", 31))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"countryCode\":31,\"country\":\"Netherlands\",\"city\":\"Amsterdam\"}"));
+                .andExpect(content().json(
+                        """
+                            {
+                                "countryCode":31,
+                                "country":"Netherlands",
+                                "city":"Amsterdam"
+                            }
+                        """
+                ));
 
         verify(countryService, times(1)).findByCountryCode(31);
     }
 
     @Test
-    public void 指定した国番号が存在しない場合は例外メッセージをスローすること() throws Exception {
+    void 指定した国番号が存在しない場合は例外メッセージをスローすること() throws Exception {
         when(countryService.findByCountryCode(999)).thenThrow(new CountryNotFoundException("Country with code 999 not found"));
 
         mockMvc.perform(get("/countries/{country_code}", 999))
                 .andExpect(status().isNotFound())
-                .andExpect(content().json("{\"message\": \"Country with code 999 not found\"}"));
+                .andExpect(content().json(
+                        """
+                            {
+                                "message": "Country with code 999 not found"
+                            }
+                        """
+                ));
 
         verify(countryService, times(1)).findByCountryCode(999);
     }
 
     @Test
-    public void 新たな国番号と国名と都市名を登録すること() throws Exception {
+    void 新たな国番号と国名と都市名を登録すること() throws Exception {
         when(countryService.insert(31, "Netherlands", "Amsterdam")).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
 
         mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
-                """
-                {
-                   "countryCode": 31,
-                   "country": "Netherlands",
-                   "city": "Amsterdam"
-                }
-                """
+                        """
+                        {
+                        "countryCode": 31,
+                        "country": "Netherlands",
+                        "city": "Amsterdam"
+                        }
+                        """
                 ))
                 .andExpect(status().isCreated())
-                .andExpect(content().json("{\"message\": \"country created\"}"));
+                .andExpect(content().json(
+                        """
+                            {
+                                "message":"country created"
+                            }
+                        """
+                ));
 
         verify(countryService, times(1)).insert(31, "Netherlands", "Amsterdam");
     }
 
     @Test
-    public void 登録しようとした国番号が既に存在する場合は例外メッセージをスローすること() throws Exception {
-        when(countryService.findByCountryCode(31)).thenThrow(new CountryDuplicatedException("Country with code 31 duplicated"));
+    void 登録しようとした国番号が既に存在する場合は例外メッセージをスローすること() throws Exception {
+        Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
+        when(countryService.insert(31, "Netherlands", "Amsterdam")).thenThrow(new CountryDuplicatedException("Country with code 31 duplicated"));
 
-        mockMvc.perform(get("/countries/{country_code}", 31))
+        mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                "countryCode": 31,
+                "country": "Netherlands",
+                "city": "Amsterdam"
+                }
+                """
+                ))
                 .andExpect(status().isConflict())
-                .andExpect(content().json("{\"message\": \"Country with code 31 duplicated\"}"));
+                .andExpect(content().json(
+                        """
+                            {
+                            "message":"Country with code 31 duplicated"
+                            }
+                        """
+                ));
 
-        verify(countryService, times(1)).findByCountryCode(31);
+        verify(countryService, times(1)).insert(31, "Netherlands", "Amsterdam");
     }
 
     @Test
-    public void 国番号を指定して国名と都市名を更新すること() throws Exception {
+    void 国番号を指定して国名と都市名を更新すること() throws Exception {
         Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
         when(countryService.update(31, "Netherlands", "Amsterdam")).thenReturn(existingCountry);
 
@@ -136,19 +200,31 @@ class CountryControllerTest {
                         """
                 ))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"message\": \"country updated\"}"));
+                .andExpect(content().json(
+                        """
+                            {
+                                "message":"country updated"
+                            }
+                        """
+                ));
 
         verify(countryService, times(1)).update(31, "Holland", "Rotterdam");
     }
 
     @Test
-    public void 国番号を指定して国を削除すること() throws Exception {
+    void 国番号を指定して国を削除すること() throws Exception {
         Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
         when(countryService.delete(31)).thenReturn(existingCountry);
 
         mockMvc.perform(delete("/countries/{country_code}", 31))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"message\": \"country deleted\"}"));
+                .andExpect(content().json(
+                        """
+                            {
+                                "message":"country deleted"
+                            }
+                        """
+                ));
 
         verify(countryService, times(1)).delete(31);
     }

--- a/src/test/java/com/example/country/CountryControllerTest.java
+++ b/src/test/java/com/example/country/CountryControllerTest.java
@@ -40,18 +40,18 @@ class CountryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
-                            [
-                                {
-                                    "countryCode":31,
-                                    "country":"Netherlands",
-                                    "city":"Amsterdam"
-                                },
-                                {
-                                    "countryCode":33,
-                                    "country":"France",
-                                    "city":"Paris"
-                                }
-                            ]
+                        [
+                            {
+                                "countryCode":31,
+                                "country":"Netherlands",
+                                "city":"Amsterdam"
+                            },
+                            {
+                                "countryCode":33,
+                                "country":"France",
+                                "city":"Paris"
+                            }
+                        ]
                         """
                 ));
 
@@ -68,13 +68,13 @@ class CountryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
-                            [
-                                {
-                                    "countryCode":31,
-                                    "country":"Netherlands",
-                                    "city":"Amsterdam"
-                                }
-                            ]
+                        [
+                            {
+                                "countryCode":31,
+                                "country":"Netherlands",
+                                "city":"Amsterdam"
+                            }
+                        ]
                         """
                 ));
 
@@ -82,7 +82,7 @@ class CountryControllerTest {
     }
 
     @Test
-    void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
+    void 指定した存在しない国名や都市名の頭文字で空の配列を返却すること() throws Exception {
         when(countryService.getCountries("k", "y")).thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/countries")
@@ -91,7 +91,7 @@ class CountryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
-                            []
+                        []
                         """
                 ));
 
@@ -106,11 +106,11 @@ class CountryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
-                            {
-                                "countryCode":31,
-                                "country":"Netherlands",
-                                "city":"Amsterdam"
-                            }
+                        {
+                            "countryCode":31,
+                            "country":"Netherlands",
+                            "city":"Amsterdam"
+                        }
                         """
                 ));
 
@@ -125,9 +125,9 @@ class CountryControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(content().json(
                         """
-                            {
-                                "message": "Country with code 999 not found"
-                            }
+                        {
+                            "message":"Country with code 999 not found"
+                        }
                         """
                 ));
 
@@ -139,20 +139,20 @@ class CountryControllerTest {
         when(countryService.insert(31, "Netherlands", "Amsterdam")).thenReturn(new Country(31, "Netherlands", "Amsterdam"));
 
         mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
-                        """
-                        {
-                        "countryCode": 31,
-                        "country": "Netherlands",
-                        "city": "Amsterdam"
-                        }
-                        """
+                """
+                {
+                    "countryCode":31,
+                    "country":"Netherlands",
+                    "city":"Amsterdam"
+                }
+                """
                 ))
                 .andExpect(status().isCreated())
                 .andExpect(content().json(
                         """
-                            {
-                                "message":"country created"
-                            }
+                        {
+                            "message":"country created"
+                        }
                         """
                 ));
 
@@ -167,18 +167,18 @@ class CountryControllerTest {
         mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
                 """
                 {
-                "countryCode": 31,
-                "country": "Netherlands",
-                "city": "Amsterdam"
+                    "countryCode":31,
+                    "country":"Netherlands",
+                    "city":"Amsterdam"
                 }
                 """
                 ))
                 .andExpect(status().isConflict())
                 .andExpect(content().json(
                         """
-                            {
+                        {
                             "message":"Country with code 31 duplicated"
-                            }
+                        }
                         """
                 ));
 
@@ -191,24 +191,50 @@ class CountryControllerTest {
         when(countryService.update(31, "Netherlands", "Amsterdam")).thenReturn(existingCountry);
 
         mockMvc.perform(patch("/countries/{country_code}", 31).contentType(MediaType.APPLICATION_JSON).content(
-                        """
-                        {
-                           "countryCode": 31,
-                           "country": "Holland",
-                           "city": "Rotterdam"
-                        }
-                        """
+                """
+                {
+                    "countryCode":31,
+                    "country":"Holland",
+                    "city":"Rotterdam"
+                }
+                """
                 ))
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
-                            {
-                                "message":"country updated"
-                            }
+                        {
+                            "message":"country updated"
+                        }
                         """
                 ));
 
         verify(countryService, times(1)).update(31, "Holland", "Rotterdam");
+    }
+
+    @Test
+    void 更新しようと指定した国番号が存在しない場合は例外をスローすること() throws Exception {
+        Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
+        when(countryService.update(47, "Norway", "Oslo")).thenThrow(new CountryNotFoundException("Country with code 47 not found"));
+
+        mockMvc.perform(patch("/countries/{country_code}", 47).contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                    "countryCode":47,
+                    "country":"Norway",
+                    "city":"Oslo"
+                }
+                """
+                ))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(
+                        """
+                        {
+                            "message":"Country with code 47 not found"
+                        }
+                        """
+                ));
+
+        verify(countryService, times(1)).update(47, "Norway", "Oslo");
     }
 
     @Test
@@ -220,12 +246,30 @@ class CountryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
-                            {
-                                "message":"country deleted"
-                            }
+                        {
+                            "message":"country deleted"
+                        }
                         """
                 ));
 
         verify(countryService, times(1)).delete(31);
+    }
+
+    @Test
+    void 削除しようと指定した国番号が存在しない場合は例外をスローすること() throws Exception {
+        Country existingCountry = new Country(31, "Netherlands", "Amsterdam");
+        when(countryService.delete(47)).thenThrow(new CountryNotFoundException("Country with code 47 not found"));
+
+        mockMvc.perform(delete("/countries/{country_code}", 47))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(
+                        """
+                        {
+                            "message":"Country with code 47 not found"
+                        }
+                        """
+                ));
+
+        verify(countryService, times(1)).delete(47);
     }
 }

--- a/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
@@ -136,7 +136,7 @@ class CountryRestApiIntegrationTest {
                         }
                         """
                 ));
-}
+    }
 
     @Test
     @DataSet(value = "datasets/countries.yml")

--- a/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
@@ -1,0 +1,228 @@
+package integrationtest;
+
+import com.example.country.CountryApplication;
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = CountryApplication.class)
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CountryRestApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 全ての国を取得すること() throws Exception {
+        String response = mockMvc.perform(get("/countries"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals(
+                    """
+                    [
+                        {
+                            "countryCode":36,
+                            "country":"Hungary",
+                            "city":"Budapest"
+                        },
+                        {
+                            "countryCode":43,
+                            "country":"Austria",
+                            "city":"Vienna"
+                        },
+                        {
+                            "countryCode":420,
+                            "country":"The Czech Republic",
+                            "city":"Prague"
+                        }
+                    ]
+                    """,
+                    response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した国名と都市名の頭文字を含む国を取得すること() throws Exception {
+        String response = mockMvc.perform(get("/countries")
+                        .param("countryStartsWith", "h")
+                        .param("cityStartsWith", "b"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals(
+                """
+                    [
+                        {
+                            "countryCode":36,
+                            "country":"Hungary",
+                            "city":"Budapest"
+                        }
+                    ]
+                    """,
+                    response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
+        String response = mockMvc.perform(get("/countries")
+                    .param("countryStartsWith", "c")
+                    .param("cityStartsWith", "d"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals(
+                """
+                     []
+                     """,
+                    response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した国番号を取得すること() throws Exception {
+        String response = mockMvc.perform(get("/countries/{country_code}", 36))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals(
+                """
+                    {
+                        "countryCode":36,
+                        "country":"Hungary",
+                        "city":"Budapest"
+                    }
+                    """,
+                    response, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 指定した国番号が存在しない場合は例外メッセージをスローすること() throws Exception {
+        mockMvc.perform(get("/countries/{country_code}", 999))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(
+                        """
+                            {
+                                "message":"Country with code 999 not found"
+                            }
+                            """
+                ));
+}
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @ExpectedDataSet(value = "datasets/insert-countries.yml")
+    @Transactional
+    void 新たな国番号と国名と都市名を登録すること() throws Exception {
+        mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
+                    """
+                        {
+                            "countryCode":385,
+                            "country":"Croatia",
+                            "city":"Zagreb"
+                        }
+                        """
+                ))
+                .andExpect(status().isCreated())
+                .andExpect(content().json(
+                        """
+                            {
+                                "message":"country created"
+                            }
+                            """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 登録しようとした国番号が既に存在する場合は例外メッセージをスローすること() throws Exception {
+        mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
+                        """
+                            {
+                                "countryCode":36,
+                                "country":"Hungary",
+                                "city":"Budapest"
+                            }
+                            """
+                ))
+                .andExpect(status().isConflict())
+                .andExpect(content().json(
+                        """
+                            {
+                                "message":"Country with code 36 duplicated"
+                            }
+                            """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @ExpectedDataSet(value = "datasets/update-countries.yml")
+    @Transactional
+    void 国番号を指定して国名と都市名を更新すること() throws Exception {
+        mockMvc.perform(patch("/countries/{country_code}", 36).contentType(MediaType.APPLICATION_JSON).content(
+                        """
+                        {
+                           "countryCode": 36,
+                           "country": "Republic of Hungary",
+                           "city": "Szentendre"
+                        }
+                        """
+                ))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        """
+                        {
+                            "message":"country updated"
+                        }
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @ExpectedDataSet(value = "datasets/delete-countries.yml")
+    @Transactional
+    void 国番号を指定して国を削除すること() throws Exception {
+        mockMvc.perform(delete("/countries/{country_code}", 420))
+                .andExpect(status().isOk())
+                .andExpect(content().json(
+                        """
+                        {
+                            "message":"country deleted"
+                        }
+                        """
+                ));
+    }
+
+}

--- a/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
@@ -42,26 +42,26 @@ class CountryRestApiIntegrationTest {
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
         JSONAssert.assertEquals(
-                    """
-                    [
-                        {
-                            "countryCode":36,
-                            "country":"Hungary",
-                            "city":"Budapest"
-                        },
-                        {
-                            "countryCode":43,
-                            "country":"Austria",
-                            "city":"Vienna"
-                        },
-                        {
-                            "countryCode":420,
-                            "country":"The Czech Republic",
-                            "city":"Prague"
-                        }
-                    ]
-                    """,
-                    response, JSONCompareMode.STRICT);
+                """
+                [
+                    {
+                        "countryCode":36,
+                        "country":"Hungary",
+                        "city":"Budapest"
+                    },
+                    {
+                        "countryCode":43,
+                        "country":"Austria",
+                        "city":"Vienna"
+                    },
+                    {
+                        "countryCode":420,
+                        "country":"The Czech Republic",
+                        "city":"Prague"
+                    }
+                ]
+                """,
+                response, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -76,15 +76,15 @@ class CountryRestApiIntegrationTest {
 
         JSONAssert.assertEquals(
                 """
-                    [
-                        {
-                            "countryCode":36,
-                            "country":"Hungary",
-                            "city":"Budapest"
-                        }
-                    ]
-                    """,
-                    response, JSONCompareMode.STRICT);
+                [
+                    {
+                        "countryCode":36,
+                        "country":"Hungary",
+                        "city":"Budapest"
+                    }
+                ]
+                """,
+                response, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -114,13 +114,13 @@ class CountryRestApiIntegrationTest {
 
         JSONAssert.assertEquals(
                 """
-                    {
-                        "countryCode":36,
-                        "country":"Hungary",
-                        "city":"Budapest"
-                    }
-                    """,
-                    response, JSONCompareMode.STRICT);
+                {
+                    "countryCode":36,
+                    "country":"Hungary",
+                    "city":"Budapest"
+                }
+                """,
+                response, JSONCompareMode.STRICT);
     }
 
     @Test

--- a/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/CountryRestApiIntegrationTest.java
@@ -90,7 +90,7 @@ class CountryRestApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/countries.yml")
     @Transactional
-    void 指定した存在しない国名や都市名の頭文字で何も返さないこと() throws Exception {
+    void 指定した存在しない国名や都市名の頭文字で空の配列を返却すること() throws Exception {
         String response = mockMvc.perform(get("/countries")
                     .param("countryStartsWith", "c")
                     .param("cityStartsWith", "d"))
@@ -99,9 +99,9 @@ class CountryRestApiIntegrationTest {
 
         JSONAssert.assertEquals(
                 """
-                     []
-                     """,
-                    response, JSONCompareMode.STRICT);
+                []
+                """,
+                response, JSONCompareMode.STRICT);
     }
 
     @Test
@@ -131,10 +131,10 @@ class CountryRestApiIntegrationTest {
                 .andExpect(status().isNotFound())
                 .andExpect(content().json(
                         """
-                            {
-                                "message":"Country with code 999 not found"
-                            }
-                            """
+                        {
+                            "message":"Country with code 999 not found"
+                        }
+                        """
                 ));
 }
 
@@ -144,21 +144,21 @@ class CountryRestApiIntegrationTest {
     @Transactional
     void 新たな国番号と国名と都市名を登録すること() throws Exception {
         mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
-                    """
-                        {
-                            "countryCode":385,
-                            "country":"Croatia",
-                            "city":"Zagreb"
-                        }
-                        """
+                """
+                {
+                    "countryCode":385,
+                    "country":"Croatia",
+                    "city":"Zagreb"
+                }
+                """
                 ))
                 .andExpect(status().isCreated())
                 .andExpect(content().json(
                         """
-                            {
-                                "message":"country created"
-                            }
-                            """
+                        {
+                            "message":"country created"
+                        }
+                        """
                 ));
     }
 
@@ -167,21 +167,21 @@ class CountryRestApiIntegrationTest {
     @Transactional
     void 登録しようとした国番号が既に存在する場合は例外メッセージをスローすること() throws Exception {
         mockMvc.perform(post("/countries").contentType(MediaType.APPLICATION_JSON).content(
-                        """
-                            {
-                                "countryCode":36,
-                                "country":"Hungary",
-                                "city":"Budapest"
-                            }
-                            """
+                """
+                {
+                    "countryCode":36,
+                    "country":"Hungary",
+                    "city":"Budapest"
+                }
+                """
                 ))
                 .andExpect(status().isConflict())
                 .andExpect(content().json(
                         """
-                            {
-                                "message":"Country with code 36 duplicated"
-                            }
-                            """
+                        {
+                            "message":"Country with code 36 duplicated"
+                        }
+                        """
                 ));
     }
 
@@ -191,19 +191,42 @@ class CountryRestApiIntegrationTest {
     @Transactional
     void 国番号を指定して国名と都市名を更新すること() throws Exception {
         mockMvc.perform(patch("/countries/{country_code}", 36).contentType(MediaType.APPLICATION_JSON).content(
-                        """
-                        {
-                           "countryCode": 36,
-                           "country": "Republic of Hungary",
-                           "city": "Szentendre"
-                        }
-                        """
+                """
+                {
+                    "countryCode":36,
+                    "country":"Republic of Hungary",
+                    "city":"Szentendre"
+                }
+                """
                 ))
                 .andExpect(status().isOk())
                 .andExpect(content().json(
                         """
                         {
                             "message":"country updated"
+                        }
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 更新しようとした国番号が存在しない場合は例外メッセージをスローすること() throws Exception {
+        mockMvc.perform(patch("/countries/{country_code}", 385).contentType(MediaType.APPLICATION_JSON).content(
+                """
+                {
+                    "countryCode":385,
+                    "country":"Croatia",
+                    "city":"Zagreb"
+                }
+                """
+                ))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(
+                        """
+                        {
+                            "message":"Country with code 385 not found"
                         }
                         """
                 ));
@@ -220,6 +243,21 @@ class CountryRestApiIntegrationTest {
                         """
                         {
                             "message":"country deleted"
+                        }
+                        """
+                ));
+    }
+
+    @Test
+    @DataSet(value = "datasets/countries.yml")
+    @Transactional
+    void 削除しようとした国番号が存在しない場合は例外メッセージをスローすること() throws Exception {
+        mockMvc.perform(delete("/countries/{country_code}", 385))
+                .andExpect(status().isNotFound())
+                .andExpect(content().json(
+                        """
+                        {
+                            "message":"Country with code 385 not found"
                         }
                         """
                 ));


### PR DESCRIPTION
# 概要
Spring + MySQL + MyBatis を使用し、CRUD処理を実装します。今回は結合テストを実装しました。
（+で前々回のControllerクラスの単体テストで誤っていた箇所の修正、jsonの体裁の整え、public、privateの削除をしてます。）

# 動作確認
- 下記9項目の動作を確認しました。
<img width="1364" alt="Screenshot 2024-08-31 at 15 44 19" src="https://github.com/user-attachments/assets/7c829724-c297-4d8d-b510-a551ebd8c76d">

- 下記テスト名と実際の内容とに相違があったため、コードを修正しました。
<img width="1360" alt="Screenshot 2024-08-31 at 16 17 19" src="https://github.com/user-attachments/assets/5186ff63-a215-420a-a92a-e87492aa337a">

- jsonの体裁の整え、public、privateの削除を加えたのち、動作確認しました。
<img width="1359" alt="Screenshot 2024-08-31 at 16 18 26" src="https://github.com/user-attachments/assets/a2c93ad6-aabc-4a1d-bd8c-d7f405486a27">
